### PR TITLE
Fix cut-off activities on mobile

### DIFF
--- a/src/components/Activities.jsx
+++ b/src/components/Activities.jsx
@@ -72,8 +72,11 @@ function ActivitiesOnOneDay({
   error = null,
   options = {},
 }) {
-  const shouldShow =
-    (activities && activities.length > 0) || isLoading || error;
+  const shouldShow = !!(
+    (activities && activities.length > 0) ||
+    isLoading ||
+    error
+  );
 
   const date = new Date();
   date.setFullYear(year);
@@ -82,9 +85,10 @@ function ActivitiesOnOneDay({
   // awkward hard-coded heights since can't transition between auto heights
   // doesn't work when zoomed out significantly
   // todo: find a better solution to height transitions
-  const totalHeight = 400;
-  const titleAndErrorHeight = 245;
-  const titleAndLoadingHeight = 107;
+  // note height is larger on mobile
+  const totalHeight = 650;
+  const titleAndErrorHeight = 250;
+  const titleAndLoadingHeight = 110;
   const zeroHeight = 0;
   const height = shouldShow
     ? isLoading
@@ -99,7 +103,7 @@ function ActivitiesOnOneDay({
       className="height-transition"
       style={{
         overflow: "hidden",
-        height,
+        maxHeight: height,
       }}
     >
       <h2>
@@ -107,6 +111,8 @@ function ActivitiesOnOneDay({
       </h2>
 
       {isLoading && <Loading task={`fetch ${year} activities`} />}
+
+      {shouldShow || <div style={{ minHeight: 40 }}></div>}
 
       <div className="activities-row">
         {activities &&

--- a/src/components/activities.css
+++ b/src/components/activities.css
@@ -109,5 +109,5 @@
 }
 
 .height-transition {
-  transition: height 1.5s;
+  transition: max-height 2.5s;
 }

--- a/src/components/pages/Sample.jsx
+++ b/src/components/pages/Sample.jsx
@@ -18,8 +18,8 @@ export default function Sample() {
   const allActivities = sampleActivities.map((activities) =>
     activities.map(parseActivity)
   );
-  const [activities, setActivities] = useState(allActivities.map(() => null));
-  const len = activities.length;
+  const len = allActivities.length;
+  const [activities, setActivities] = useState(Array(len).fill(null));
   const [areLoading, setAreLoading] = useState(Array(len).fill(true));
   const errors = Array(len).fill(null);
 


### PR DESCRIPTION
Use max-height instead of height, and other minor adjustments.